### PR TITLE
[format]: left-pad variable length fields with "0"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ lib/
 target/
 pom.xml
 pom.xml.asc
+.clj-kondo/
 *.diff
 .DS_Store
 .lein-deps-sum
 .lein-failures
 .lein-repl-history
+.lsp/
 .nrepl-port
 .settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2023-04-25
+
+### Changed
+
+- left-pad variable length field length descriptions with "0"
+
 ## [0.5.0] - 2023-04-10
 
 ### Changed
 
-- include field name in error output when field is too short ([commit #ac6c3858f0](https://github.com/oakmac/com.oakmac.iso8583/commit/ac6c3858f0ea9b36ddaca352b6e8f7c7afaafcb1))
+- include field name in error output when field is too short
+  ([commit #ac6c3858f0](https://github.com/oakmac/com.oakmac.iso8583/commit/ac6c3858f0ea9b36ddaca352b6e8f7c7afaafcb1))
 - minor: whitespace / formatting changes
 
 ## [0.4.0] - 2022-12-06
@@ -28,19 +35,20 @@ All notable changes to this project will be documented in this file.
 - use `com.oakmac.iso8583` for namespaces
 - update Clojure to version 1.11.1
 
-[clj-kondo]:https://github.com/clj-kondo/clj-kondo
-[Midje]:https://github.com/marick/Midje
-[clojure.test]:https://clojure.github.io/clojure/clojure.test-api.html
+[clj-kondo]: https://github.com/clj-kondo/clj-kondo
+[midje]: https://github.com/marick/Midje
+[clojure.test]: https://clojure.github.io/clojure/clojure.test-api.html
 
 ## [0.1.0]
 
-- [alpian/clj-iso8583] had `"0.1"` as a version listed in the `project.clj` file as of commit `3e41ce5790711a9d50961d6a48bced150a95391c`
+- [alpian/clj-iso8583] had `"0.1"` as a version listed in the `project.clj` file
+  as of commit `3e41ce5790711a9d50961d6a48bced150a95391c`
 
-[alpian/clj-iso8583]:https://github.com/alpian/clj-iso8583
-
-[Unreleased]: https://github.com/oakmac/com.oakmac.iso8583/compare/v0.5.0...HEAD
+[alpian/clj-iso8583]: https://github.com/alpian/clj-iso8583
+[unreleased]: https://github.com/oakmac/com.oakmac.iso8583/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/oakmac/com.oakmac.iso8583/releases/tag/v0.5.0
 [0.4.0]: https://github.com/oakmac/com.oakmac.iso8583/releases/tag/v0.4.0
 [0.3.0]: https://github.com/oakmac/com.oakmac.iso8583/releases/tag/v0.3.0
 [0.2.0]: https://github.com/oakmac/com.oakmac.iso8583/releases/tag/v0.2.0
-[0.1.0]: https://github.com/alpian/clj-iso8583/tree/3e41ce5790711a9d50961d6a48bced150a95391c
+[0.1.0]:
+  https://github.com/alpian/clj-iso8583/tree/3e41ce5790711a9d50961d6a48bced150a95391c

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.oakmac/iso8583 "0.5.0"
+(defproject com.oakmac/iso8583 "0.5.1"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Parse ISO 8583 messages into Clojure maps and vice versa (updated fork of alpian/clj-iso8583)"

--- a/src-clj/com/oakmac/iso8583/format.clj
+++ b/src-clj/com/oakmac/iso8583/format.clj
@@ -1,6 +1,12 @@
 (ns com.oakmac.iso8583.format
   (:require
-    [com.oakmac.iso8583.binary :refer [bytes-to-ascii bytes-to-hex]]))
+   [com.oakmac.iso8583.binary :refer [bytes-to-ascii bytes-to-hex]]))
+
+(defn- pad-left-with [p l v]
+  (if (< (count v) l)
+    (let [s (concat (repeat (- l (count v)) p) v)]
+      (apply str (take l s)))
+    v))
 
 (defn variable-length-field [field-length]
   {:reader
@@ -12,7 +18,7 @@
 
    :writer
    (fn [encoder-fn _field-name value]
-     (str (count value) (encoder-fn value)))})
+     (str (pad-left-with "0" field-length (str (count value))) (encoder-fn value)))})
 
 (defn- error [field-name error-msg data]
   {:errors [(str "(field=" (name field-name) ") Error: " error-msg ". The data: [" data "]")]})

--- a/src-clj/com/oakmac/iso8583/format.clj
+++ b/src-clj/com/oakmac/iso8583/format.clj
@@ -1,12 +1,7 @@
 (ns com.oakmac.iso8583.format
   (:require
-   [com.oakmac.iso8583.binary :refer [bytes-to-ascii bytes-to-hex]]))
-
-(defn- pad-left-with [p l v]
-  (if (< (count v) l)
-    (let [s (concat (repeat (- l (count v)) p) v)]
-      (apply str (take l s)))
-    v))
+   [com.oakmac.iso8583.binary :refer [bytes-to-ascii bytes-to-hex]]
+   [com.oakmac.iso8583.util.string :as util.string]))
 
 (defn variable-length-field [field-length]
   {:reader
@@ -18,7 +13,9 @@
 
    :writer
    (fn [encoder-fn _field-name value]
-     (str (pad-left-with "0" field-length (str (count value))) (encoder-fn value)))})
+     (str
+      (util.string/pad-left-with "0" field-length (str (count value)))
+      (encoder-fn value)))})
 
 (defn- error [field-name error-msg data]
   {:errors [(str "(field=" (name field-name) ") Error: " error-msg ". The data: [" data "]")]})

--- a/src-clj/com/oakmac/iso8583/util/string.clj
+++ b/src-clj/com/oakmac/iso8583/util/string.clj
@@ -1,0 +1,7 @@
+(ns com.oakmac.iso8583.util.string)
+
+(defn pad-left-with [p l v]
+  (if (< (count v) l)
+    (let [s (concat (repeat (- l (count v)) p) v)]
+      (apply str (take l s)))
+    v))

--- a/test/com/oakmac/iso8583/util/string_test.clj
+++ b/test/com/oakmac/iso8583/util/string_test.clj
@@ -1,0 +1,13 @@
+(ns com.oakmac.iso8583.util.string-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [com.oakmac.iso8583.util.string :as util.str]))
+
+(deftest left-pad-test
+  (is (= (util.str/pad-left-with "" 0 "") ""))
+  (is (= (util.str/pad-left-with " " 2 "1") " 1"))
+  (is (= (util.str/pad-left-with "0" 3 "17") "017"))
+  (is (= (util.str/pad-left-with "*" 2 "foo") "foo"))
+  (is (= (util.str/pad-left-with "*" 3 "foo") "foo"))
+  (is (= (util.str/pad-left-with "*" 4 "foo") "*foo"))
+  (is (= (util.str/pad-left-with "*" 5 "foo") "**foo")))

--- a/test/com/oakmac/iso8583/writer_test.clj
+++ b/test/com/oakmac/iso8583/writer_test.clj
@@ -29,4 +29,4 @@
                            ;; This is a 3 digit variable length field with
                            ;; length 17. Expect it to be 0 padded to 017.
                            :message-reason-code "because i said so"}))
-           (str (binary/bytes-to-hex "0200") "7000000000000000" (binary/bytes-to-hex "161111222233334444011000000000006660017because i said so"))))))
+           (str (binary/bytes-to-hex "0200") "7000000000000100" (binary/bytes-to-hex "161111222233334444011000000000006660017because i said so"))))))

--- a/test/com/oakmac/iso8583/writer_test.clj
+++ b/test/com/oakmac/iso8583/writer_test.clj
@@ -1,9 +1,9 @@
 (ns com.oakmac.iso8583.writer-test
   (:require
-    [clojure.test :refer [deftest is testing]]
-    [com.oakmac.iso8583.binary :as binary]
-    [com.oakmac.iso8583.format-iso8583 :as format-iso8583]
-    [com.oakmac.iso8583.writer :as writer]))
+   [clojure.test :refer [deftest is testing]]
+   [com.oakmac.iso8583.binary :as binary]
+   [com.oakmac.iso8583.format-iso8583 :as format-iso8583]
+   [com.oakmac.iso8583.writer :as writer]))
 
 (deftest write-test
   (testing "Can write the message-type"
@@ -21,9 +21,12 @@
 (deftest write-fields-test
   (testing "Can write a few fields"
     (is (= (binary/bytes-to-hex
-             (writer/write (format-iso8583/field-definitions)
-               {:message-type "0200"
-                :pan "1111222233334444"
-                :processing-code "011000"
-                :transaction-amount "000000006660"}))
-           (str (binary/bytes-to-hex "0200") "7000000000000000" (binary/bytes-to-hex "161111222233334444011000000000006660"))))))
+            (writer/write (format-iso8583/field-definitions)
+                          {:message-type "0200"
+                           :pan "1111222233334444"
+                           :processing-code "011000"
+                           :transaction-amount "000000006660"
+                           ;; This is a 3 digit variable length field with
+                           ;; length 17. Expect it to be 0 padded to 017.
+                           :message-reason-code "because i said so"}))
+           (str (binary/bytes-to-hex "0200") "7000000000000000" (binary/bytes-to-hex "161111222233334444011000000000006660017because i said so"))))))


### PR DESCRIPTION
Without this fields described as having variable-length encoding but only two digits giving that coding are incorrectly written: